### PR TITLE
0.8.0 - fixed more cube syntax bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The assumptions are as follows:
 
 1. **Foreign Key Naming**: **dwa** presumes that a foreign key will carry the exact same name as the primary key it refers to, barring the suffix. So, a foreign key referring to `order_pk` would be named `order_fk`.
 
+1. **Lowercase and Underscores**: **table** and **column names** are assumed to `be_in_this_format`
+
 
 ***
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Data Warehouse Automation (dwa) is a tool designed to automate routine tasks involving your cloud-based data warehouse. 
 
-The current version supports **Snowflake data warehouses** and generates **Cube.js** semantic files.
+The current version supports [**Snowflake data warehouses**](https://www.snowflake.com/en/) and generates [**Cube.js**](https://cube.dev/) semantic files.
 
 This is a work in progress. If you would like to make changes accomodate your workflow, see section `contribute`.
 

--- a/data_warehouse_automation/cube/cube_base_layer.py
+++ b/data_warehouse_automation/cube/cube_base_layer.py
@@ -92,9 +92,9 @@ def generate_cube_js_base_file( tables_columns, file_path, field_descriptions_di
             # Write measures
             file.write('  measures: {\n\n')
             file.write(',\n\n'.join('    ' + measure for measure in measures))
-            if measures:
+            if measures: # Add a comma before the count if there are other measures
                 file.write(',\n\n')
-            file.write(f'    count{table_name_camel_case.capitalize()}: {{\n      type: "count"\n    }}\n\n  }}\n')
+            file.write(f'    count{table_name_camel_case.capitalize()}: {{\n      type: "count_distinct"\n    }}\n\n  }}\n')
 
             # Write the end of the cube
             file.write('});\n\n')

--- a/data_warehouse_automation/cube/cube_base_layer.py
+++ b/data_warehouse_automation/cube/cube_base_layer.py
@@ -72,9 +72,9 @@ def generate_cube_js_base_file( tables_columns, file_path, field_descriptions_di
 
                 # Prep column's attributes based on rules
                 if column_name.lower().endswith('_pk'): # Primary Key
-                    dimensions.append(f'{column_name_camel_case}: {{\n      sql: `${{CUBE}}."{column_name}"`,\n      description: `{column_description}`, \n      type: "string",\n      primaryKey: true,\n      public: false\n    }}')
-                if column_name.lower().endswith('_fk'): # Foreign Key
-                    dimensions.append(f'{column_name_camel_case}: {{\n      sql: `${{CUBE}}."{column_name}"`,\n      description: `{column_description}`, \n      type: "string",\n      public: false\n    }}')
+                    dimensions.append(f'{column_name_camel_case}: {{\n      sql: `${{CUBE}}."{column_name}"`,\n      description: `{column_description}`, \n      type: "string",\n      primaryKey: true,\n      shown: false\n    }}')
+                elif column_name.lower().endswith('_fk'): # Foreign Key
+                    dimensions.append(f'{column_name_camel_case}: {{\n      sql: `${{CUBE}}."{column_name}"`,\n      description: `{column_description}`, \n      type: "string",\n      shown: false\n    }}')
                 elif data_type.lower() in ['text', 'varchar', 'string', 'char', 'binary', 'variant']: # String types
                     dimensions.append(f'{column_name_camel_case}: {{\n      sql: `${{CUBE}}."{column_name}"`,\n      description: `{column_description}`, \n      type: "string" \n    }}')
                 elif data_type.lower() in ['number', 'numeric', 'float', 'float64', 'integer', 'int', 'smallint', 'bigint']: # Numeric types

--- a/data_warehouse_automation/cube/cube_base_layer.py
+++ b/data_warehouse_automation/cube/cube_base_layer.py
@@ -16,7 +16,7 @@ def to_camel_case(name):
     return components[0].lower() + ''.join(x.title() for x in components[1:])
 
 
-def generate_cube_js_base_file( tables_columns, file_path, field_descriptions_dictionary, inferred_join_cardinalities ):
+def generate_cube_js_base_file( tables_columns, file_path, field_descriptions_dictionary, inferred_join_cardinalities, concise_table_names, table_pks ):
 
     # Create the necessary directories
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
@@ -94,7 +94,8 @@ def generate_cube_js_base_file( tables_columns, file_path, field_descriptions_di
             file.write(',\n\n'.join('    ' + measure for measure in measures))
             if measures: # Add a comma before the count if there are other measures
                 file.write(',\n\n')
-            file.write(f'    {to_camel_case("count_" + table_name)}: {{\n      type: "count_distinct"\n    }}\n\n  }}\n')
+            # Final measure is always the count
+            file.write(f'    {to_camel_case("count_" + concise_table_names[table_name])}: {{\n      type: "count_distinct",\n      sql:`${{CUBE}}."{table_pks[table_name][0]}"`\n    }}\n\n  }}\n')
 
             # Write the end of the cube
             file.write('});\n\n')

--- a/data_warehouse_automation/cube/cube_base_layer.py
+++ b/data_warehouse_automation/cube/cube_base_layer.py
@@ -94,7 +94,7 @@ def generate_cube_js_base_file( tables_columns, file_path, field_descriptions_di
             file.write(',\n\n'.join('    ' + measure for measure in measures))
             if measures: # Add a comma before the count if there are other measures
                 file.write(',\n\n')
-            file.write(f'    count{table_name_camel_case.capitalize()}: {{\n      type: "count_distinct"\n    }}\n\n  }}\n')
+            file.write(f'    {to_camel_case("count_" + table_name)}: {{\n      type: "count_distinct"\n    }}\n\n  }}\n')
 
             # Write the end of the cube
             file.write('});\n\n')

--- a/data_warehouse_automation/inferring/remove_table_prefixes.py
+++ b/data_warehouse_automation/inferring/remove_table_prefixes.py
@@ -1,0 +1,28 @@
+"""
+This module processes a dictionary representing a database schema and removes specified prefixes 
+from the table names. The input includes a list of potential prefixes, and the function iteratively 
+checks and removes these from each table name. The output is a new dictionary mapping the original 
+table names to the adjusted names, facilitating easier reference and more readable code within the 
+broader application.
+
+"""
+
+def remove_prefixes_from_table_names(schema_dict):
+
+    prefixes = [
+        'dim_',
+        'fact_',
+        'fct_',
+        'xa_',
+        'obt_',
+        ]
+
+    result = {}
+    for table_name in schema_dict.keys():
+        extracted_table_name = table_name.lower()
+        for prefix in prefixes:
+            if extracted_table_name.startswith(prefix):
+                extracted_table_name = extracted_table_name[len(prefix):]
+                break
+        result[table_name] = extracted_table_name.upper()
+    return result

--- a/data_warehouse_automation/main.py
+++ b/data_warehouse_automation/main.py
@@ -10,6 +10,7 @@ from data_warehouse_automation.input.information_schema import query_snowflake_t
 from data_warehouse_automation.inferring.extract_table_pks import extract_table_pks
 from data_warehouse_automation.inferring.extract_pk_fk_pairs import extract_pk_fk_pairs
 from data_warehouse_automation.inferring.infer_join_cardinality import infer_join_cardinality
+from data_warehouse_automation.inferring.remove_table_prefixes import remove_prefixes_from_table_names
 from data_warehouse_automation.input.read_text_file import read_text_file
 from data_warehouse_automation.input.process_markdown_file_content import extract_documentation
 from data_warehouse_automation.cube.cube_base_layer import generate_cube_js_base_file
@@ -65,6 +66,9 @@ def main():
     # Close the Snowflake connection
     snowflake_connection.close()
 
+    # Remove prefixes from table names
+    concise_table_names = remove_prefixes_from_table_names(schema)
+
     # Set the file path for the cube.js base file
     file_path = 'cube/schema/base.js'
 
@@ -79,7 +83,9 @@ def main():
             schema,
             file_path,
             field_descriptions_dictionary,
-            inferred_join_cardinalities
+            inferred_join_cardinalities,
+            concise_table_names,
+            table_pks
         )
     else:
         print( 'Invalid command' )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='data_warehouse_automation',
-    version='0.7.0',
+    version='0.8.0',
     packages=find_packages(),
     install_requires=[
         'pyyaml',


### PR DESCRIPTION
dwa cube
* changed pk and fk dims from `public` to `shown`
* changed `count`
  * to `type`: `count_distinct`
  * to use a `sql:` key
* fixed `count` measure name to
  * proper camel case (`countTableName` instead of `countTablename`)
  * concise table name (`countAddresses` instead of `countDimAddresses`) based on a list of prefixes
    * new module: `remove_table_prefixes.py` handles the removal of them

README
* added assumption about lowercases and underscores
* added links to snowflake and cube

## Description & motivation
More changes after qa of base.js in cube cloud

## Checklist
- [X] My pull request represents one story (logical piece of work).
- [X] I have updated the version in `setup.py`.
- [X] My package has no residual code that is no longer used.